### PR TITLE
Add tools/install_roles.sh

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,8 +3,12 @@
     check:
       jobs:
         - ansible-tox-linters
-        - ansible-tox-molecule
+        - ansible-tox-molecule:
+            required-projects:
+              - github.com/ansible-security/ids_config
     gate:
       jobs:
         - ansible-tox-linters
-        - ansible-tox-molecule
+        - ansible-tox-molecule:
+            required-projects:
+              - github.com/ansible-security/ids_config

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,9 +1,8 @@
 ---
 dependency:
-  name: galaxy
+  name: shell
+  command: ./tools/install_roles.sh
   enabled: true
-  options:
-    role-file: requirements.yml
 driver:
   name: docker
 lint:

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,5 @@
 ---
-
 - src: geerlingguy.repo-epel
 
-- src: git+https://github.com/ansible-security/ids_config.git
+- src: git+https://github.com/ansible-security/ids_config
   name: ids_config

--- a/tools/install_roles.sh
+++ b/tools/install_roles.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -ex
+# Copyright 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+TOOLSDIR=$(dirname $0)
+
+# NOTE(pabelanger): Check if we are running in the gate, if so use cached repos
+# to avoid hitting the network.
+if [ -d /etc/dib-manifests/ ]; then
+    # TODO(pabelanger): Have molecule support existing shell variables.
+    HOME=${HOME:-/home/zuul}
+    sed -e "s|https://|file://${HOME}/src/|g" -i $TOOLSDIR/../requirements.yml
+fi
+
+# NOTE(pabelanger): We should make this role path less hardcoded, however we
+# first need to patch molecule.
+ansible-galaxy install -v -r $TOOLSDIR/../requirements.yml -p ~/.cache/molecule/ids_install/default/roles $@


### PR DESCRIPTION
This allows us to also use local git repos checked out zuul, which is
helpful to support cross project testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>