### PR TITLE
requirements.txt: depends on ansible-core

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -3,3 +3,5 @@
 
 gcc-c++ [test platform:rpm]
 python3-devel [test !platform:centos-7 platform:rpm]
+libyaml-devel [test platform:rpm]
+libyaml-dev [test platform:dpkg]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible>=2.8.0
+ansible-core


### PR DESCRIPTION
We don't need the full ansible distribution. `ansible-core` should
be enough.
